### PR TITLE
Include options-ssl-nginx.conf when building frontman image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM nginx:1.21
 
 COPY nginx.conf /etc/nginx/nginx.conf
+ADD https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf /etc/nginx/options-ssl-nginx.conf

--- a/README.md
+++ b/README.md
@@ -74,8 +74,6 @@ In order to encrypt your services using HTTPS, you need to generate a certificat
 
 Install [Certbot](https://certbot.eff.org/lets-encrypt/ubuntufocal-nginx).
 
-Put the contents from [this file](https://raw.githubusercontent.com/certbot/certbot/master/certbot-nginx/certbot_nginx/_internal/tls_configs/options-ssl-nginx.conf) into `/etc/letsencrypt/options-ssl-nginx.conf`.
-
 ### Generate certificates
 
 Stop the reverse proxy: `make stop`

--- a/https-server.template
+++ b/https-server.template
@@ -6,7 +6,7 @@
         listen       443 ssl;
         ssl_certificate /etc/letsencrypt/live/$_SERVER_NAME_$/fullchain.pem;
         ssl_certificate_key /etc/letsencrypt/live/$_SERVER_NAME_$/privkey.pem;
-        include /etc/letsencrypt/options-ssl-nginx.conf;
+        include /etc/nginx/options-ssl-nginx.conf;
 
         # Redirect non-https traffic to https
         if ($scheme != "https") {


### PR DESCRIPTION
Reason for changing path inside the container is because otherwise the mounted volume will overwrite any files added to /etc/letsencrypt/* during build