### PR TITLE
Minor changes to flags/arguments

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL := /bin/bash
 
 start:
-	if [ -a nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
+	if [ -e nginx.conf ]; then mv nginx.conf nginx.conf.bak; fi;
 	python3 generate-conf.py
-	docker-compose up --build -d
+	docker-compose up --build --detach
 
 stop:
 	docker-compose stop

--- a/generate-conf.py
+++ b/generate-conf.py
@@ -25,6 +25,6 @@ with open("servers.json") as f:
     new_conf = nginx_conf.replace("$$$_SERVERS_$$$", all_servers)
     print(new_conf)
 
-    out_file = open("nginx.conf", "a")
+    out_file = open("nginx.conf", "x")
     out_file.write(new_conf)
     out_file.close()


### PR DESCRIPTION
Use `-e` to check if file exist.
As far as I can tell `-a` is a binary operator to check that two expressions are true (source: `man test`)

Use `x` flag when opening nginx.conf for modification.
Since we move nginx.conf to nginx.conf.bak prior to running generate-conf.py - We never expect this to exist. Then it makes more sense to fail (`x`) if the file for some reason exist, instead of appending (`a`).