### PR TITLE
Add certbot-related targets to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,5 +25,4 @@ generate-certs:
 	fi;
 
 renew-certs:
-	docker-compose run --service-ports certbot renew \
-		--dry-run; \
+	docker-compose run --service-ports certbot renew

--- a/Makefile
+++ b/Makefile
@@ -8,3 +8,22 @@ start:
 stop:
 	docker-compose stop
 
+validate-certs:
+	python3 validate-certs.py
+
+generate-certs:
+	MISSING_CERTS=$$(python3 print-missing-certs.py); \
+	if [ -z "$$MISSING_CERTS" ]; then \
+		echo "Found no certificates to generate"; \
+	else \
+		docker-compose run --service-ports certbot certonly \
+			--domains "$$MISSING_CERTS" \
+			--non-interactive \
+			--standalone \
+			--agree-tos \
+			--register-unsafely-without-email; \
+	fi;
+
+renew-certs:
+	docker-compose run --service-ports certbot renew \
+		--dry-run; \

--- a/Makefile
+++ b/Makefile
@@ -12,17 +12,17 @@ validate-certs:
 	python3 validate-certs.py
 
 generate-certs:
-	MISSING_CERTS=$$(python3 print-missing-certs.py); \
-	if [ -z "$$MISSING_CERTS" ]; then \
-		echo "Found no certificates to generate"; \
-	else \
+	HTTPS_DOMAINS=$$(python3 print-https-certs.py); \
+	for domain in $${HTTPS_DOMAINS//,/ }; \
+	do \
 		docker-compose run --service-ports certbot certonly \
-			--domains "$$MISSING_CERTS" \
+			--domains "$$domain" \
+			--cert-name "$$domain" \
 			--non-interactive \
 			--standalone \
 			--agree-tos \
 			--register-unsafely-without-email; \
-	fi;
+	done \
 
 renew-certs:
 	docker-compose run --service-ports certbot renew

--- a/README.md
+++ b/README.md
@@ -100,9 +100,6 @@ If you'd like to automate the process of generating certificates, there are thre
 **renew-certs**
  - Attempts to renew any certificates previously obtained with certbot.
 
-## How to contribute
-Feel free to open a pull request! All contributions, no matter how small, are more than welcome. Happy hacking!
-
 ## Running unit tests
 
 ```python
@@ -128,3 +125,6 @@ python3 -m pytest tests
 cd e2e
 ./run-test.sh
 ```
+
+## How to contribute
+Feel free to open a pull request! All contributions, no matter how small, are more than welcome. Happy hacking!

--- a/README.md
+++ b/README.md
@@ -87,6 +87,22 @@ The contents from `/etc/letsencrypt/` will be mounted into the Docker container.
 
 You need to repeat this process every 90 days unless you set up a cronjob to do it for you.
 
+### Automation of certificate generation
+
+If you'd like to automate the process of generating certificates, there are three additional targets in the [Makefile](./Makefile) that may help you.
+
+**validate-certs**
+ - Iterates the servers in servers.json, returns a non-zero exit status if any of the servers (with https: true) does not have fullchain.pem and privkey.pem files in the expected locations.
+
+**generate-certs**
+ - Iterates the servers in servers.json, attempting to generate a certificate with certbot for any servers (with https: true) that does not have fullchain.pem and privkey.pem files in the expected locations.
+
+**renew-certs**
+ - Attempts to renew any certificates previously obtained with certbot.
+
+## How to contribute
+Feel free to open a pull request! All contributions, no matter how small, are more than welcome. Happy hacking!
+
 ## Running unit tests
 
 ```python
@@ -112,6 +128,3 @@ python3 -m pytest tests
 cd e2e
 ./run-test.sh
 ```
-
-## How to contribute
-Feel free to open a pull request! All contributions, no matter how small, are more than welcome. Happy hacking!

--- a/cert_utils.py
+++ b/cert_utils.py
@@ -1,0 +1,18 @@
+import json
+import os
+import sys
+
+def is_https(server):
+    return server['https']
+
+def cert_missing(domain_name):
+    chain_exists = os.path.exists("/etc/letsencrypt/live/{}/fullchain.pem".format(domain_name))
+    private_exists = os.path.exists("/etc/letsencrypt/live/{}/privkey.pem".format(domain_name))
+    return not (chain_exists and private_exists)
+
+def missing_certs():
+    with open("servers.json") as f:
+        servers_input = json.loads(f.read())
+        https_servers = filter(is_https, servers_input)
+        https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
+        return list(filter(cert_missing, https_server_names))

--- a/cert_utils.py
+++ b/cert_utils.py
@@ -10,9 +10,12 @@ def cert_missing(domain_name):
     private_exists = os.path.exists("/etc/letsencrypt/live/{}/privkey.pem".format(domain_name))
     return not (chain_exists and private_exists)
 
-def missing_certs():
+def https_domains():
     with open("servers.json") as f:
         servers_input = json.loads(f.read())
         https_servers = filter(is_https, servers_input)
         https_server_names = map(lambda https_server: https_server['server_name'], https_servers)
-        return list(filter(cert_missing, https_server_names))
+        return list(https_server_names)
+
+def missing_certs():
+    return list(filter(cert_missing, https_domains()))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,4 +11,11 @@ services:
         - "host.docker.internal:host-gateway"
     volumes:
         - /etc/letsencrypt/:/etc/letsencrypt/
-
+  certbot:
+    image: certbot/certbot
+    ports:
+      - 80:80
+    volumes:
+      - /etc/letsencrypt/:/etc/letsencrypt/
+    profiles:
+      - tools

--- a/print-https-certs.py
+++ b/print-https-certs.py
@@ -1,0 +1,3 @@
+from cert_utils import https_domains
+
+print(",".join(https_domains()))

--- a/print-missing-certs.py
+++ b/print-missing-certs.py
@@ -1,0 +1,3 @@
+from cert_utils import missing_certs
+
+print(",".join(missing_certs()))

--- a/print-missing-certs.py
+++ b/print-missing-certs.py
@@ -1,3 +1,0 @@
-from cert_utils import missing_certs
-
-print(",".join(missing_certs()))

--- a/validate-certs.py
+++ b/validate-certs.py
@@ -1,0 +1,9 @@
+import sys
+from cert_utils import missing_certs
+
+missing_certs = missing_certs()
+if missing_certs:
+    print("Missing certs: " + ",".join(missing_certs), file=sys.stderr)
+    sys.exit(1)
+
+sys.exit(0)


### PR DESCRIPTION
Add three new certbot-related targets to Makefile. These has helped me to automate the process of obtaining and renew certificates for any https-server defined in `servers.json`.

**validate-certs**
Iterates the servers in `servers.json`, returns a non-zero exit status if any of the servers (with https: true) does not have `fullchain.pem` and `privkey.pem` files in the expected locations.

**generate-certs**
Iterates the servers in `servers.json`, attempting to generate a certificate with certbot for any server with https: true.

**renew-certs**
Attempts to renew any certificates previously obtained with certbot.