### PR TITLE
Run test workflows on merge with master and on PRs

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,6 +1,10 @@
 name: e2e tests
 
-on: [pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
 
 jobs:
   e2e-test:

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -1,6 +1,10 @@
 name: Unit tests
 
-on: [pull_request]
+on:
+  push:
+    branches: master
+  pull_request:
+    branches: master
 
 jobs:
   unit-test:


### PR DESCRIPTION
There is no reason to not run the tests on merge, it will only be an extra safety mechanism.

It will also allow us to get a "green" master branch.

Also, for the `workflow-timer` action to work well we need the data from runs on the master branch. 
We only want to compare the duration of historical runs on the master branch. We don't want to compare with duration data from runs on PRs because the master branch is the single point of truth. By running the tests on push to master we will be able to filter historical workflow runs based on branch.