### PR TITLE
Upgrade workflow-timer version to v0.0.2

### DIFF
--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,5 +18,5 @@ jobs:
           cd e2e && ./run-test.sh
 
       - name: Time reporter
-        uses: DeviesDevelopment/workflow-timer@check-trigger-event
+        uses: DeviesDevelopment/workflow-timer@v0.0.2
 

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -18,5 +18,5 @@ jobs:
           cd e2e && ./run-test.sh
 
       - name: Time reporter
-        uses: DeviesDevelopment/workflow-timer@v0.0.1
+        uses: DeviesDevelopment/workflow-timer@check-trigger-event
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,5 +25,5 @@ jobs:
           python3 -m pytest tests --verbose
 
       - name: Time reporter
-        uses: DeviesDevelopment/workflow-timer@check-trigger-event
+        uses: DeviesDevelopment/workflow-timer@v0.0.2
 

--- a/.github/workflows/unit-test.yml
+++ b/.github/workflows/unit-test.yml
@@ -25,5 +25,5 @@ jobs:
           python3 -m pytest tests --verbose
 
       - name: Time reporter
-        uses: DeviesDevelopment/workflow-timer@v0.0.1
+        uses: DeviesDevelopment/workflow-timer@check-trigger-event
 


### PR DESCRIPTION
The new version of workflow-timer will fix the "broken" master branch. 

In version v0.0.0.2, the workflow-timer will not be triggered on other events than `pull_request`